### PR TITLE
Update flake8 config for _vendor, add __init__.py to ops/_vendor

### DIFF
--- a/ops/_vendor/__init__.py
+++ b/ops/_vendor/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ skip = "ops/_vendor"
 [tool.flake8]
 max-line-length = 99
 max-doc-length = 99
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
+exclude = ["ops/_vendor", ".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 ignore = ["D105", "D107", "E203", "W503"]
 # D100, D101, D102, D103, D104: Ignore missing docstrings in tests


### PR DESCRIPTION
Minor changes:

- Ensure that `flake8` doesn't try to lint the contents of `ops/_vendor`
- Add `__init__.py` to the `ops/_vendor` directory to fix import errors in charm tests